### PR TITLE
Support passing an I2C object as constructor argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ relative coordinates.
 ## Methods
 
 ``MPU9250()`` The constructor supports the following arguments  
-  1. side_str 'X' or 'Y' (mandatory) defines the I2C interface in use.  
+  1. side_str 'X' or 'Y' (mandatory) defines the I2C interface in use. Alternatively an initialised
+I2C object may be passed.
   2. device_addr 0 or 1 (optional) Two devices may be used with addresses determined by the voltage
 on the AD0 pin. If only one device is used, this argument may be None when the device
-will be automatically detected
+will be automatically detected.
   3. transposition (optional) Enables axes to be transposed (see below).
   4. scaling  (optional) Enables axes to be inverted (see below).
 

--- a/README_MPU9150.md
+++ b/README_MPU9150.md
@@ -75,7 +75,8 @@ relative coordinates.
 ## Methods
 
 ``MPU9150()`` The constructor supports the following arguments  
-  1. side_str 'X' or 'Y' (mandatory) defines the I2C interface in use.
+  1. side_str 'X' or 'Y' (mandatory) defines the I2C interface in use. Alternatively an initialised
+I2C object may be passed.
   2. device_addr 0 or 1 (optional) Two devices may be used with addresses determined by the voltage
 on the AD0 pin. If only one device is used, this argument may be None when the device
 will be automatically detected.

--- a/imu.py
+++ b/imu.py
@@ -80,13 +80,14 @@ class InvenSenseMPU(object):
         tim = pyb.millis()                      # Ensure PSU and device have settled
         if tim < 200:
             pyb.delay(200-tim)
-
-        try:                                    # Initialise I2C
-            side = {'X': 1, 'Y': 2}[side_str.upper()]
-        except KeyError:
-            raise ValueError('I2C side must be X or Y')
-
-        self._mpu_i2c = pyb.I2C(side, pyb.I2C.MASTER)
+        if type(side_str) is str:
+            sst = side_str.upper()
+            if sst in {'X', 'Y'}:
+                self._mpu_i2c = pyb.I2C(sst, pyb.I2C.MASTER)
+            else:
+                raise ValueError('I2C side must be X or Y')
+        elif type(side_str) is pyb.I2C:
+            self._mpu_i2c = side_str
 
         if device_addr is None:
             devices = set(self._mpu_i2c.scan())


### PR DESCRIPTION
Fixes problem with bus number on Pyboard Lite: the user can pass either 'X' or 'Y' or an initialised I2C object. I've updated the docs to suit.
