### PR TITLE
uses_machine banch: platform independent version.

### DIFF
--- a/README_MPU9150.md
+++ b/README_MPU9150.md
@@ -35,8 +35,8 @@ transposing axes. The driver returns vehicle-relative coordinates.
 Example:
 Example assuming an MPU9150 connected to 'X' I2C interface on the Pyboard:
 ```python
-from mpu1250 import MPU9150
-imu = MPU9250('X')
+from mpu9150 import MPU9150
+imu = MPU9150('X')
 print(imu.accel.xyz)
 print(imu.gyro.xyz)
 print(imu.mag.xyz)

--- a/mpu9150.py
+++ b/mpu9150.py
@@ -20,18 +20,19 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 '''
+# 17th May 2017 utime replaces pyb
 # 15th June 2015 Now uses subclass of InvenSenseMPU
 
 from imu import InvenSenseMPU, bytes_toint, MPUException
 from vector3d import Vector3d
-import pyb
-
+from utime import sleep_ms
 
 def default_mag_wait():
     '''
     delay of 1ms
     '''
-    pyb.delay(1)
+    sleep_ms(1)
+
 
 
 class MPU9150(InvenSenseMPU):

--- a/vector3d.py
+++ b/vector3d.py
@@ -1,6 +1,7 @@
 # vector3d.py 3D vector class for use in inertial measurement unit drivers
 # Authors Peter Hinch, Sebastian Plamauer
 
+# V0.7 17th May 2017 pyb replaced with utime
 # V0.6 18th June 2015
 
 '''
@@ -23,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 '''
 
-import pyb
+from utime import sleep_ms
 from math import sqrt, degrees, acos, atan2
 
 
@@ -31,7 +32,7 @@ def default_wait():
     '''
     delay of 50 ms
     '''
-    pyb.delay(50)
+    sleep_ms(50)
 
 
 class Vector3d(object):


### PR DESCRIPTION
Removes pyb dependence. Tested on Pyboard and ESP8266.

In principle the MPU9150 driver should support the MPU6050 6DOF sensor but lacking hardware I'm unable to test this.