### PR TITLE
Mpu6050 baseclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 As of now, this repo holds:
 * vector3d - a vector class for IMU devices
-* imu - a base class for MPU9x50 devices
-* mpu9150 - a class for the MPU9150 and MPU6050
+* imu - a base class for MPU9x50 devices. Supports the MPU6050.
+* mpu9150 - a class for the MPU9150
 * mpu9250 - a class for the MPU9250
 
 vector3d will eventually be spun out to serve as common starting point for other

--- a/README_MPU9150.md
+++ b/README_MPU9150.md
@@ -24,7 +24,7 @@ transposing axes. The driver returns vehicle-relative coordinates.
 
 ### Wiring the sensor to the pyboard
 
-| pyboard| mpu9250 |
+| pyboard| mpu9150 |
 |:------:|:-------:|
 | VIN    | 3V3     |
 | GND    | GND     |
@@ -52,7 +52,6 @@ from imu import MPU6050
 imu = MPU6050('X')
 print(imu.accel.xyz)
 print(imu.gyro.xyz)
-print(imu.mag.xyz)
 print(imu.temperature)
 print(imu.accel.z)
 ```
@@ -304,13 +303,13 @@ I2C adress of the magnetometer.
 
 Incorrect values such as  
 ```python
-imu = MPU9250('Z')
+imu = MPU9150('Z')
 ```
 will raise a ValueError with a meaningful error message.  
 When any communication with the IMU takes place it is possible for the I2C bus to lock up.
 This is normally a consequence of hardware failure such as the device being connected incorrectly
 or leads being too long. In this instance a custom MPUException will be raised with a
-dscriptive message. This is derived from Python's OSError: the user may trap either in the hope
+descriptive message. This is derived from Python's OSError: the user may trap either in the hope
 of continuing operation. In my experience this seldom works: if the I2C bus locks up a
 power cycle is required to clear it.
 

--- a/mpu9250.py
+++ b/mpu9250.py
@@ -25,11 +25,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 '''
 
-from imu import InvenSenseMPU, bytes_toint, MPUException
+from imu import MPU6050, bytes_toint, MPUException
 from vector3d import Vector3d
 
 
-class MPU9250(InvenSenseMPU):
+class MPU9250(MPU6050):
     '''
     MPU9250 constructor arguments
     1. side_str 'X' or 'Y' depending on the Pyboard I2C interface being used

--- a/mpu9250.py
+++ b/mpu9250.py
@@ -39,7 +39,6 @@ class MPU9250(MPU6050):
           coordinates rather than those of the sensor itself. See readme.
     '''
 
-    _mpu_addr = (104, 105)  # addresses of MPU9250 determined by voltage on pin AD0
     _mag_addr = 12          # Magnetometer address
     _chip_id = 113
 


### PR DESCRIPTION
This implements MPU6050 support in the IMU base class, minimising the code which needs to be imported for this device. Now tested with MPU6050 hardware by @DaneGrinder.