### PR TITLE
Fix bad chip ID error when using MPU9250 class with MPU9255 sensor

### DIFF
--- a/mpu9255.py
+++ b/mpu9255.py
@@ -1,0 +1,34 @@
+# mpu9255.py MicroPython driver for the InvenSense MPU9255 inertial measurement unit
+# Authors Peter Hinch, Sebastian Plamauer
+# V0.1 7th October 2022
+
+'''
+mpu9255 is a micropython module for the InvenSense MPU9255 sensor.
+It measures acceleration, turn rate and the magnetic field in three axis.
+The MPU9255 sensor is functionally equivalent to the MPU9250 except for the
+device ID or chip ID which is 0x73.
+
+The MIT License (MIT)
+Copyright (c) 2014 Sebastian Plamauer, oeplse@gmail.com, Peter Hinch
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+'''
+
+from mpu9250 import MPU9250
+
+
+class MPU9255(MPU9250):
+    _chip_id = 0x73


### PR DESCRIPTION
This PR resolves issue https://github.com/micropython-IMU/micropython-mpu9x50/issues/25.